### PR TITLE
Fix mozilla/science.mozilla.org#189 - Add sorting functionality for getting all projects

### DIFF
--- a/app/scienceapi/projects/views.py
+++ b/app/scienceapi/projects/views.py
@@ -1,4 +1,5 @@
 from rest_framework.generics import ListAPIView
+from rest_framework import filters
 
 from scienceapi.projects.models import Project
 from scienceapi.projects.serializers import ProjectWithDetailsSerializer
@@ -12,3 +13,8 @@ class ProjectsListView(ListAPIView):
     queryset = Project.objects.all()
     serializer_class = ProjectWithDetailsSerializer
     pagination_class = None
+    filter_backends = (filters.OrderingFilter,)
+    ordering_fields = (
+        'date_created',
+        'date_updated',
+    )

--- a/app/scienceapi/settings.py
+++ b/app/scienceapi/settings.py
@@ -157,7 +157,8 @@ REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': [
         'rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly',
     ],
-    'PAGE_SIZE': 10
+    'ORDERING_PARAM': 'sort',
+    'PAGE_SIZE': 10,
 }
 
 STATIC_ROOT = root('staticfiles')


### PR DESCRIPTION
This is not fully complete because it does not allow sorting by number of contributors...and I have no idea how to do that because the contributor list is populated at the serializer level. We either have to add the contributor stuff to the view or figure out if there is some kind of `after_serialization` hook that we can tap into in the view and order it there