### PR TITLE
Fix mozilla/science.mozilla.org#461 - Rename github contributor properties

### DIFF
--- a/app/scienceapi/utility/github.py
+++ b/app/scienceapi/utility/github.py
@@ -23,9 +23,9 @@ def get_contributors(owner, repository):
     else:
         contributors = [
             {
-                'username': contributor.login,
+                'github_username': contributor.login,
                 'url': contributor.html_url,
-                'image_url': contributor.avatar_url
+                'avatar_url': contributor.avatar_url
             }
             for contributor in response
         ]


### PR DESCRIPTION
r+ from @alicoding verbally.