### PR TITLE
Allow regex based CORS whitelisting

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ This will create a simple environment for local development then you can start w
 | DJANGO_SECRET_KEY | String | Required: anything that is something people can't guess!|
 | DEBUG | Boolean | Required: `True` or `False` |
 |CORS_WHITELIST| String | Optional, comma separated list of domains (without space), e.g. `google.ca,.herokuapp.com`. For allowing all domains, set to `*`|
+|CORS_REGEX_WHITELIST| String | Optional, comma separated list of domain regex patterns (without space), e.g. `^(https?://)?(\w+\.)?google\.com$,\.herokuapp\.com$`|
 
 ### Database migration
 

--- a/app/scienceapi/settings.py
+++ b/app/scienceapi/settings.py
@@ -14,10 +14,13 @@ import environ
 
 app = environ.Path(__file__) - 1
 root = app - 1
-env = environ.Env(DEBUG=(bool, False),
-                  ALLOWED_HOSTS=(list, []),
-                  CORS_WHITELIST=(tuple, ()),
-                  GH_TOKEN=(str, None))
+env = environ.Env(
+    DEBUG=(bool, False),
+    ALLOWED_HOSTS=(list, []),
+    CORS_WHITELIST=(tuple, ()),
+    CORS_REGEX_WHITELIST=(tuple, ()),
+    GH_TOKEN=(str, None),
+)
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = root()
@@ -176,3 +179,4 @@ if '*' in env('CORS_WHITELIST'):
     CORS_ORIGIN_ALLOW_ALL = True
 else:
     CORS_ORIGIN_WHITELIST = env('CORS_WHITELIST')
+    CORS_ORIGIN_REGEX_WHITELIST = env('CORS_REGEX_WHITELIST')

--- a/env.sample
+++ b/env.sample
@@ -2,4 +2,5 @@ DEBUG=True
 DJANGO_SECRET_KEY=secret
 DATABASE_URL=postgres://postgres:postgres@postgres:5432/postgres
 GH_TOKEN=
-CORS_WHITELIST=
+CORS_WHITELIST=*
+CORS_REGEX_WHITELIST=


### PR DESCRIPTION
This will allow us to enable the science.mozilla.org review apps on Heroku to use our api