### PR TITLE
update psycopg2 to the latest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 -r requirements.common.txt
 
-psycopg2==2.6.2
+psycopg2==2.7.3


### PR DESCRIPTION
I got this error while doing pip install requirements:

```Collecting psycopg2==2.6.2 (from -r requirements.txt (line 3))
  Downloading psycopg2-2.6.2.tar.gz (376kB)
    100% |████████████████████████████████| 378kB 2.9MB/s
    Complete output from command python setup.py egg_info:
    running egg_info
    creating pip-egg-info/psycopg2.egg-info
    writing pip-egg-info/psycopg2.egg-info/PKG-INFO
    writing dependency_links to pip-egg-info/psycopg2.egg-info/dependency_links.txt
    writing top-level names to pip-egg-info/psycopg2.egg-info/top_level.txt
    writing manifest file 'pip-egg-info/psycopg2.egg-info/SOURCES.txt'
    warning: manifest_maker: standard file '-c' not found

    Error: could not determine PostgreSQL version from '10.0'
```

Updating psycopg2 to the latest version fixed it.